### PR TITLE
Fix a client crash on multiplayer servers

### DIFF
--- a/Expanded Bow Enchanting/src/main/kotlin/com/smushytaco/expanded_bow_enchanting/ExpandedBowEnchanting.kt
+++ b/Expanded Bow Enchanting/src/main/kotlin/com/smushytaco/expanded_bow_enchanting/ExpandedBowEnchanting.kt
@@ -12,7 +12,7 @@ object ExpandedBowEnchanting : ModInitializer {
     const val MOD_ID = "expanded_bow_enchanting"
     lateinit var config: ModConfiguration
         private set
-    private lateinit var dynamicRegistryManager: DynamicRegistryManager
+    private var dynamicRegistryManager: DynamicRegistryManager? = null
     override fun onInitialize() {
         AutoConfig.register(ModConfiguration::class.java) { definition: Config, configClass: Class<ModConfiguration> ->
             GsonConfigSerializer(definition, configClass)
@@ -20,5 +20,5 @@ object ExpandedBowEnchanting : ModInitializer {
         config = AutoConfig.getConfigHolder(ModConfiguration::class.java).config
         ServerLifecycleEvents.SERVER_STARTED.register { server -> dynamicRegistryManager = server.registryManager }
     }
-    fun isSameEnchantment(enchantment: Enchantment, enchantmentRegistryKey: RegistryKey<Enchantment>) = dynamicRegistryManager.getOptional(RegistryKeys.ENCHANTMENT).getOrNull()?.getEntry(enchantment)?.matchesKey(enchantmentRegistryKey) ?: false
+    fun isSameEnchantment(enchantment: Enchantment, enchantmentRegistryKey: RegistryKey<Enchantment>) = dynamicRegistryManager?.getOptional(RegistryKeys.ENCHANTMENT)?.getOrNull()?.getEntry(enchantment)?.matchesKey(enchantmentRegistryKey) ?: false
 }


### PR DESCRIPTION
Fixes a crash that occurs on every multiplayer server when putting two items in an anvil
Related to [issue-2443178995](https://github.com/SmushyTaco/Expanded-Bow-Enchanting/issues/2#issue-2443178995)